### PR TITLE
feat: make sure load method only runs on the client

### DIFF
--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -1,6 +1,9 @@
 import type { TimerType } from "$lib/types";
 import { browser } from '$app/environment';
 
+// Ensures that the load function only loads on the client side
+export const ssr = false;
+
 function generateUniqueId() {
     return Math.random().toString(36).slice(2, 9);
 }
@@ -10,25 +13,27 @@ export async function load() {
 
     // Make sure we're in the browser
     if (browser) {
+        console.log('Loading timers from local storage')
         // If we are, load the timers from local storage - if they exist.
         const storedTimers = localStorage.getItem('timers');
         timers = storedTimers ? JSON.parse(storedTimers) : [];
+        if (timers.length === 0) {
+            // Initialize the timers with the default timer
+            timers = [
+                {
+                    timerLengthInSeconds: 63,
+                    timerName: 'Default',
+                    timerId: generateUniqueId(),
+                    linked: true
+                }
+            ]
+        }
+        return {
+            timers: timers
+        };
     }
-    if (timers.length === 0) {
-        // Initialize the timers with the default timer
-        timers = [
-            {
-                timerLengthInSeconds: 60,
-                timerName: 'Default',
-                timerId: generateUniqueId(),
-                linked: true
-            }
-        ]
-    }
-
 
     return {
-        timers: timers || []
-
-    };
+        timers: []
+    }
 }


### PR DESCRIPTION
Make sure that the load method only runs on the client side. This ensures that there is no odd behavior with trying to load local storage in the server but then not loading it in the client...we want it to only and always load in the client.