### PR TITLE
New chain icon

### DIFF
--- a/src/lib/icons/ChevronDoubleDown.svelte
+++ b/src/lib/icons/ChevronDoubleDown.svelte
@@ -1,0 +1,23 @@
+<script>
+	import IconWrapper from './IconWrapper.svelte';
+	export let active = true;
+</script>
+
+<IconWrapper>
+	<div class="relative">
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			fill="none"
+			viewBox="0 0 24 24"
+			stroke-width="1.5"
+			stroke="currentColor"
+			class={`w-6 h-6 ${active ? 'stroke-primary' : ''}`}
+		>
+			<path
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				d="m4.5 5.25 7.5 7.5 7.5-7.5m-15 6 7.5 7.5 7.5-7.5"
+			/>
+		</svg>
+	</div>
+</IconWrapper>

--- a/src/lib/icons/ChevronToggle.svelte
+++ b/src/lib/icons/ChevronToggle.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+	import ChevronDoubleDown from './ChevronDoubleDown.svelte';
+	import DoubleBars from './DoubleBars.svelte';
+
+	export let active = true;
+</script>
+
+{#if active}
+	<ChevronDoubleDown {active} />
+{:else}
+	<DoubleBars />
+{/if}

--- a/src/lib/icons/DoubleBars.svelte
+++ b/src/lib/icons/DoubleBars.svelte
@@ -1,0 +1,16 @@
+<script>
+	import IconWrapper from './IconWrapper.svelte';
+</script>
+
+<IconWrapper>
+	<svg
+		xmlns="http://www.w3.org/2000/svg"
+		fill="none"
+		viewBox="0 0 24 24"
+		stroke-width="1.5"
+		stroke="currentColor"
+		class="w-6 h-6 stroke-error"
+	>
+		<path stroke-linecap="round" stroke-linejoin="round" d="M3.75 9h16.5m-16.5 6.75h16.5" />
+	</svg>
+</IconWrapper>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -90,7 +90,7 @@
 	}
 </script>
 
-<h1 class="text-2xl text-center">Simple Timer(s)</h1>
+<h1 class="text-2xl text-center">Simple Timers</h1>
 
 {#each localTimers as timer, i (timer.timerId)}
 	{#if i > 0}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,6 +3,8 @@
 	import { browser } from '$app/environment';
 	import type { CreateTimerType } from '$lib/types';
 	import Link from '$lib/icons/Link.svelte';
+	import ChevronDoubleDown from '$lib/icons/ChevronDoubleDown.svelte';
+	import ChevronToggle from '$lib/icons/ChevronToggle.svelte';
 
 	export let data;
 	let intervalTime = 30; // 1 minute - the time to add or subtract from the timer
@@ -93,9 +95,9 @@
 {#each localTimers as timer, i (timer.timerId)}
 	{#if i > 0}
 		<div class="w-full relative">
-			<div class="absolute flex flex-row w-full items-center justify-center">
+			<div class="absolute flex flex-row w-full items-center justify-center -top-[4px]">
 				<button on:click={() => saveTimerLinkStatus(i - 1, !localTimers[i - 1].linked)}
-					><Link active={localTimers[i - 1].linked} /></button
+					><ChevronToggle active={localTimers[i - 1].linked} /></button
 				>
 			</div>
 			<div class="divider" />


### PR DESCRIPTION
Change the icon that indicates whether the timers are chained together (i.e. whether the next one will start when the current one ends or not).
I tried to make it a little more clear what is happening when a user clicks the button. It's subtle, and I think there is more that can be improved here, but it's at least an improvement.

Here's what it looks like when they are chained together:
<img width="200" alt="image" src="https://github.com/SYN-tactic/simple-timers/assets/13920926/6bf8221a-0579-430e-ad13-6e4966f0339e">

Here's what it looks like when they are not chained together:
<img width="200" alt="image" src="https://github.com/SYN-tactic/simple-timers/assets/13920926/470130e6-2f14-4ef1-89a2-d456e1ba68cd">
